### PR TITLE
Set follow_symlinks false as a workaround

### DIFF
--- a/os-hardening/minimal_access.sls
+++ b/os-hardening/minimal_access.sls
@@ -5,7 +5,7 @@ hardening-read-only-folders:
     - names: {{ hardening.read_only_folders }}
     - user: root
     - group: root
-    - follow_symlinks: True
+    - follow_symlinks: False
     - dir_mode: 755
     - file_mode: 755
     - recurse:
@@ -38,4 +38,3 @@ allow-sudo:
     - mode: 4755
     - replace: False
 {% endif %}
-


### PR DESCRIPTION
As workaround for this

```yml
       ----------
                 ID: hardening-read-only-folders
           Function: file.directory
               Name: /usr/bin
             Result: False
            Comment: Directory /usr/bin updated
              
              The following errors were encountered:
              
              - /usr/bin/vmware-user: File not found
            Started: 15:50:22.966944
           Duration: 148.715 ms
            Changes:   
```

```bash
ls -l /usr/bin/vmware-user
lrwxrwxrwx 1 root root 24 May  8 16:51 /usr/bin/vmware-user -> vmware-user-suid-wrapper
stat /usr/bin/vmware-user-suid-wrapper
stat: cannot stat '/usr/bin/vmware-user-suid-wrapper': No such file or directory
```